### PR TITLE
Preserve history.state in sanitizeQueryParameters

### DIFF
--- a/src/extensionClient.js
+++ b/src/extensionClient.js
@@ -110,7 +110,7 @@ class ExtensionClient {
     newUrl.searchParams.delete('expires_in');
     newUrl.searchParams.delete('access_token');
     newUrl.searchParams.delete('id_token');
-    history.replaceState({}, undefined, newUrl.toString());
+    history.replaceState(history.state, undefined, newUrl.toString());
 
     return this.getTokenResponse();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1009,7 +1009,7 @@ export class LoginClient {
     newUrl.searchParams.delete('expires_in');
     newUrl.searchParams.delete('access_token');
     newUrl.searchParams.delete('id_token');
-    history.replaceState({}, undefined, newUrl.toString());
+    history.replaceState(history.state, undefined, newUrl.toString());
   }
 }
 

--- a/tests/loginClient/sanitizeQueryParameters.test.js
+++ b/tests/loginClient/sanitizeQueryParameters.test.js
@@ -1,0 +1,68 @@
+import { describe, it, afterEach, expect, vi } from 'vitest';
+
+import { LoginClient } from '../../src/index.js';
+import windowManager from '../../src/windowManager.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loginClient.js', () => {
+  describe('sanitizeQueryParameters', () => {
+    it('removes auth-related query parameters from the URL', () => {
+      const loginClient = new LoginClient({ authressApiUrl: 'https://unit-test.authress.io', skipBackgroundCredentialsCheck: true });
+
+      vi.spyOn(windowManager, 'getCurrentLocation').mockImplementation(() =>
+        new URL('https://app.example.com/page?nonce=abc&iss=https://auth.example.com&code=xyz&keep=this')
+      );
+
+      const replaceStateSpy = vi.fn();
+      vi.stubGlobal('history', { state: null, replaceState: replaceStateSpy });
+
+      loginClient.sanitizeQueryParameters();
+
+      expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+      const [, , url] = replaceStateSpy.mock.calls[0];
+      const resultUrl = new URL(url);
+      expect(resultUrl.searchParams.has('nonce')).toBe(false);
+      expect(resultUrl.searchParams.has('iss')).toBe(false);
+      expect(resultUrl.searchParams.has('code')).toBe(false);
+      expect(resultUrl.searchParams.get('keep')).toBe('this');
+    });
+
+    it('preserves existing history.state when replacing URL', () => {
+      const loginClient = new LoginClient({ authressApiUrl: 'https://unit-test.authress.io', skipBackgroundCredentialsCheck: true });
+
+      vi.spyOn(windowManager, 'getCurrentLocation').mockImplementation(() =>
+        new URL('https://app.example.com/?code=abc')
+      );
+
+      const routerState = { __TSR_key: 'abc', idx: 3 };
+      const replaceStateSpy = vi.fn();
+      vi.stubGlobal('history', { state: routerState, replaceState: replaceStateSpy });
+
+      loginClient.sanitizeQueryParameters();
+
+      expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+      const [stateArg] = replaceStateSpy.mock.calls[0];
+      expect(stateArg).toBe(routerState);
+    });
+
+    it('passes null state when history.state is null', () => {
+      const loginClient = new LoginClient({ authressApiUrl: 'https://unit-test.authress.io', skipBackgroundCredentialsCheck: true });
+
+      vi.spyOn(windowManager, 'getCurrentLocation').mockImplementation(() =>
+        new URL('https://app.example.com/?code=abc')
+      );
+
+      const replaceStateSpy = vi.fn();
+      vi.stubGlobal('history', { state: null, replaceState: replaceStateSpy });
+
+      loginClient.sanitizeQueryParameters();
+
+      expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+      const [stateArg] = replaceStateSpy.mock.calls[0];
+      expect(stateArg).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #74

`sanitizeQueryParameters` (and the equivalent in `extensionClient.js`) called `history.replaceState({}, ...)` to strip auth callback params from the URL. The empty `{}` wipes any state that SPA routers (e.g. TanStack Router) have already stored via `history.replaceState` during initialization. This can cause route re-evaluation, component remounts, and lost in-flight operations like the token exchange.

Fix: pass `history.state` instead of `{}` so the URL gets cleaned without touching router state.

**Changes:**
- `src/index.js` — `sanitizeQueryParameters()`
- `src/extensionClient.js` — URL cleanup after token exchange

**Tests:**
- Auth params are stripped, unrelated params are kept
- Existing `history.state` is forwarded to `replaceState`
- `null` state is handled correctly