### PR TITLE
Fix misleading NotLoggedIn error messages in getUserProfile and unlinkIdentity

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -496,7 +496,7 @@ export class LoginClient {
    */
   async getUserProfile() {
     if (!this.getUserIdentity()) {
-      const e = Error('User must be logged in to unlink an account.');
+      const e = Error('User must be logged in to fetch the user profile.');
       e.code = 'NotLoggedIn';
       throw e;
     }
@@ -506,7 +506,7 @@ export class LoginClient {
       accessToken = await this.ensureToken({ timeoutInMillis: 100 });
     } catch (error) {
       if (error.code === 'TokenTimeout') {
-        const e = Error('User must be logged into an existing account before linking a second account.');
+        const e = Error('User must be logged in to fetch the user profile.');
         e.code = 'NotLoggedIn';
         throw e;
       }
@@ -553,7 +553,7 @@ export class LoginClient {
       accessToken = await this.ensureToken({ timeoutInMillis: 100 });
     } catch (error) {
       if (error.code === 'TokenTimeout') {
-        const e = Error('User must be logged into an existing account before linking a second account.');
+        const e = Error('User must be logged in to unlink an account.');
         e.code = 'NotLoggedIn';
         throw e;
       }


### PR DESCRIPTION
## Summary
- `getUserProfile()` threw `"User must be logged in to unlink an account."` and `"...before linking a second account."` from its `NotLoggedIn` / `TokenTimeout` branches — both references to the wrong flow. Replaced with profile-fetch copy.
- `unlinkIdentity()`'s `TokenTimeout` branch threw the link-flow message; corrected to `"User must be logged in to unlink an account."`.

Fixes #76

## Test plan
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] Verify a `NotLoggedIn` error surfaced from `getUserProfile()` reports the new profile-fetch message