### PR TITLE
Add onStartAuthentication callback to authenticate() and linkIdentity()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,8 @@ export interface AuthenticationParameters {
   multiAccount?: boolean;
   /** Remove all cookies, LocalStorage, and SessionStorage related data before logging in. In most cases, this helps prevent corrupted browser state from affecting your user's experience. (Default: **true**) */
   clearUserDataBeforeLogin?: boolean;
+  /** Called with the authentication response (including authenticationRequestId) after the authentication request is created but before the browser navigates to the identity provider. If the callback returns a Promise, navigation is blocked until it resolves. */
+  onStartAuthentication?: (response: AuthenticateResponse) => void | Promise<void>;
 }
 
 export interface LinkIdentityParameters {
@@ -68,6 +70,8 @@ export interface LinkIdentityParameters {
   redirectUrl?: string;
   /** Overrides the connection specific properties from the Authress Identity Connection to pass to the identity provider */
   connectionProperties?: Record<string, string>;
+  /** Called with the authentication response after the authentication request is created but before the browser navigates to the identity provider. If the callback returns a Promise, navigation is blocked until it resolves. */
+  onStartAuthentication?: (response: AuthenticateResponse) => void | Promise<void>;
 }
 
 export interface OneTimeCodeLinkIdentityParameters {

--- a/src/index.js
+++ b/src/index.js
@@ -608,7 +608,7 @@ export class LoginClient {
    * @param {Object} [connectionProperties] Connection specific properties to pass to the identity provider. Can be used to override default scopes for example.
    * @return {Promise<void>} Is there a valid existing session.
    */
-  async linkIdentity({ connectionId, tenantLookupIdentifier, redirectUrl, connectionProperties }) {
+  async linkIdentity({ connectionId, tenantLookupIdentifier, redirectUrl, connectionProperties, onStartAuthentication }) {
     if (!connectionId && !tenantLookupIdentifier) {
       const e = Error('connectionId or tenantLookupIdentifier must be specified');
       e.code = 'InvalidConnection';
@@ -649,6 +649,13 @@ export class LoginClient {
         connectionProperties,
         applicationId: this.applicationId
       }, headers);
+
+      if (onStartAuthentication) {
+        await onStartAuthentication({
+          authenticationUrl: requestOptions.data.authenticationUrl,
+          authenticationRequestId: requestOptions.data.authenticationRequestId
+        });
+      }
       windowManager.assign(requestOptions.data.authenticationUrl);
     } catch (error) {
       this.logger.log({ title: '[Authress Login SDK] Failed to start user identity link', error });
@@ -761,7 +768,7 @@ export class LoginClient {
    */
   async authenticate(options = {}) {
     const {
-      connectionId, tenantLookupIdentifier, inviteId, redirectUrl, force, responseLocation, flowType, connectionProperties, openType, multiAccount, clearUserDataBeforeLogin, audiences
+      connectionId, tenantLookupIdentifier, inviteId, redirectUrl, force, responseLocation, flowType, connectionProperties, openType, multiAccount, clearUserDataBeforeLogin, audiences, onStartAuthentication
     } = (options || {});
 
     if (responseLocation && responseLocation !== 'cookie' && responseLocation !== 'query' && responseLocation !== 'none') {
@@ -820,6 +827,13 @@ export class LoginClient {
         };
       }
 
+
+      if (onStartAuthentication) {
+        await onStartAuthentication({
+          authenticationUrl: authResponse.data.authenticationUrl,
+          authenticationRequestId: authResponse.data.authenticationRequestId
+        });
+      }
       if (openType === 'tab') {
         const result = windowManager.open(authResponse.data.authenticationUrl, '_blank');
         if (!result || result.closed || typeof result.closed === 'undefined') {

--- a/tests/loginClient/authenticate.test.js
+++ b/tests/loginClient/authenticate.test.js
@@ -1,0 +1,122 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+import { LoginClient } from '../../src/index.js';
+import windowManager from '../../src/windowManager.js';
+import HttpClient from '../../src/httpClient.js';
+import jwtManager from '../../src/jwtManager.js';
+import userIdentityTokenStorageManager from '../../src/userIdentityTokenStorageManager.js';
+
+const authResponseData = {
+  authenticationUrl: 'https://login.authress.io/authenticate',
+  authenticationRequestId: 'req_test123'
+};
+
+function createLoginClient() {
+  const loginClient = new LoginClient({ authressApiUrl: 'https://unit-test.authress.io', skipBackgroundCredentialsCheck: true });
+  vi.spyOn(loginClient, 'userSessionExists').mockResolvedValue(false);
+  return loginClient;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  globalThis.localStorage = { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn() };
+  vi.spyOn(windowManager, 'getCurrentLocation').mockReturnValue(new URL('https://app.example.com'));
+  vi.spyOn(windowManager, 'assign').mockImplementation(() => {});
+  vi.spyOn(userIdentityTokenStorageManager, 'clear').mockImplementation(() => {});
+  vi.spyOn(jwtManager, 'getAuthCodes').mockResolvedValue({ codeVerifier: 'test-verifier', codeChallenge: 'test-challenge' });
+  vi.spyOn(jwtManager, 'calculateAntiAbuseHash').mockResolvedValue('test-hash');
+  vi.spyOn(HttpClient.prototype, 'post').mockResolvedValue({ data: authResponseData });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete globalThis.localStorage;
+});
+
+describe('loginClient.js', () => {
+  describe('authenticate', () => {
+    it('should call onStartAuthentication with the response before redirecting', async () => {
+      const callOrder = [];
+      const onStartAuthentication = vi.fn().mockImplementation(() => { callOrder.push('onStartAuthentication'); });
+      windowManager.assign.mockImplementation(() => { callOrder.push('assign'); });
+
+      const loginClient = createLoginClient();
+      const authenticatePromise = loginClient.authenticate({ connectionId: 'test-connection', onStartAuthentication });
+      await vi.runAllTimersAsync();
+      await authenticatePromise;
+
+      expect(onStartAuthentication).toHaveBeenCalledOnce();
+      expect(onStartAuthentication).toHaveBeenCalledWith({
+        authenticationUrl: authResponseData.authenticationUrl,
+        authenticationRequestId: authResponseData.authenticationRequestId
+      });
+      expect(windowManager.assign).toHaveBeenCalledOnce();
+      expect(callOrder).toEqual(['onStartAuthentication', 'assign']);
+    });
+
+    it('should await an async onStartAuthentication before redirecting', async () => {
+      let callbackResolved = false;
+      const callOrder = [];
+      const onStartAuthentication = vi.fn().mockImplementation(() => {
+        return new Promise(resolve => {
+          setTimeout(() => { callbackResolved = true; callOrder.push('onStartAuthentication'); resolve(); }, 10);
+        });
+      });
+      windowManager.assign.mockImplementation(() => { callOrder.push('assign'); });
+
+      const loginClient = createLoginClient();
+      const authenticatePromise = loginClient.authenticate({ connectionId: 'test-connection', onStartAuthentication });
+      await vi.runAllTimersAsync();
+      await authenticatePromise;
+
+      expect(callbackResolved).toBe(true);
+      expect(callOrder).toEqual(['onStartAuthentication', 'assign']);
+    });
+
+    it('should redirect without calling onStartAuthentication when it is not provided', async () => {
+      const loginClient = createLoginClient();
+      const authenticatePromise = loginClient.authenticate({ connectionId: 'test-connection' });
+      await vi.runAllTimersAsync();
+      await authenticatePromise;
+
+      expect(windowManager.assign).toHaveBeenCalledOnce();
+      expect(windowManager.assign).toHaveBeenCalledWith(authResponseData.authenticationUrl);
+    });
+
+    it('should propagate errors thrown by onStartAuthentication', async () => {
+      const onStartAuthentication = vi.fn().mockRejectedValue(new Error('Logging failed'));
+
+      const loginClient = createLoginClient();
+      await expect(loginClient.authenticate({
+        connectionId: 'test-connection',
+        onStartAuthentication
+      })).rejects.toThrow('Logging failed');
+
+      expect(windowManager.assign).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('linkIdentity', () => {
+    it('should call onStartAuthentication with the response before redirecting', async () => {
+      const callOrder = [];
+      const onStartAuthentication = vi.fn().mockImplementation(() => { callOrder.push('onStartAuthentication'); });
+      windowManager.assign.mockImplementation(() => { callOrder.push('assign'); });
+
+      const loginClient = createLoginClient();
+      vi.spyOn(loginClient, 'getUserIdentity').mockReturnValue({ sub: 'user-123' });
+      vi.spyOn(loginClient, 'ensureToken').mockResolvedValue('test-token');
+
+      const linkPromise = loginClient.linkIdentity({ connectionId: 'test-connection', onStartAuthentication });
+      await vi.runAllTimersAsync();
+      await linkPromise;
+
+      expect(onStartAuthentication).toHaveBeenCalledOnce();
+      expect(onStartAuthentication).toHaveBeenCalledWith({
+        authenticationUrl: authResponseData.authenticationUrl,
+        authenticationRequestId: authResponseData.authenticationRequestId
+      });
+      expect(callOrder).toEqual(['onStartAuthentication', 'assign']);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When `authenticate()` redirects to an external identity provider (the normal flow), it calls `window.location.assign()` and the page unloads before the method can return. The `authenticationRequestId` is created server-side and stored in `localStorage`, but the caller never receives it — the method returns `null` after the redirect, which in practice never executes because the page is already navigating away.

The `authenticationRequestId` **is** returned when the auth URL hostname matches the current page (custom login screen case), but in the standard redirect flow there's no way for calling code to observe the request ID before navigation happens.

## Use case

We need to log the `authenticationRequestId` to our backend before the redirect so we can reference it when working with Authress support to debug authentication issues. Today we can't correlate a user's login attempt with what Authress sees on their end because the ID is lost during the redirect.

A synchronous log call (e.g. `navigator.sendBeacon`) is fragile and not guaranteed to complete. We need the SDK to **await** an async callback before navigating, so the caller can reliably persist the ID.

## Solution

Add an optional `onStartAuthentication` async callback to `AuthenticationParameters` and `LinkIdentityParameters`:

```ts
onStartAuthentication?: (response: AuthenticateResponse) => void | Promise<void>;
```

The callback is invoked with `{ authenticationRequestId, authenticationUrl }` right before `windowManager.assign()` redirects. If it returns a Promise, navigation is blocked until it resolves.

**Fully backwards-compatible** — callers that don't pass the callback see no change in behavior.

### Example usage

```js
await loginClient.authenticate({
  connectionId: 'my-connection',
  redirectUrl: window.location.href,
  onStartAuthentication: async ({ authenticationRequestId }) => {
    await fetch('/api/log-auth-request', {
      method: 'POST',
      body: JSON.stringify({ authenticationRequestId }),
    });
  },
});
```

## Changes

- **`index.d.ts`**: Add `onStartAuthentication` to `AuthenticationParameters` and `LinkIdentityParameters`
- **`src/index.js`**: 
  - Destructure `onStartAuthentication` in `authenticate()` and invoke it before redirect
  - Destructure `onStartAuthentication` in `linkIdentity()` and invoke it before redirect

## Alternatives considered

- **Read from `localStorage`**: The SDK stores the nonce internally, but the key/format isn't part of the public API and is fragile to rely on
- **Use `navigator.sendBeacon`**: Best-effort, may not complete before page unload
- **Monkey-patch `window.location.assign`**: Brittle, won't survive SDK updates